### PR TITLE
Retry clients if first try fails

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -387,19 +387,19 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 
 func continuouslyRetrySchedulerClient(ctx context.Context, opts clients.Options) (*clients.Clients, error) {
 	for {
-			cli, err := clients.New(ctx, opts)
-			if err == nil {
-				return cli, nil
-			}
+		cli, err := clients.New(ctx, opts)
+		if err == nil {
+			return cli, nil
+		}
 
-			log.Errorf("Failed to initialize scheduler clients: %s. Retrying...", err)
-select {
-			case <- time.After(time.Second):
-			case <-ctx.Done():
-			  return nil, ctx.Error()
-			  }
+		log.Errorf("Failed to initialize scheduler clients: %s. Retrying...", err)
+		select {
+		case <-time.After(time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
+
 }
 
 func getPodName() string {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -292,10 +292,12 @@ func newDaprRuntime(ctx context.Context,
 	)
 
 	if runtimeConfig.SchedulerEnabled() {
-		rt.schedulerClients, err = clients.New(ctx, clients.Options{
+		opts := clients.Options{
 			Addresses: runtimeConfig.schedulerAddress,
 			Security:  sec,
-		})
+		}
+
+		rt.schedulerClients, err = continuouslyRetrySchedulerClient(ctx, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -381,6 +383,23 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 	}
 
 	return a.runnerCloser.Run(ctx)
+}
+
+func continuouslyRetrySchedulerClient(ctx context.Context, opts clients.Options) (*clients.Clients, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			cli, err := clients.New(ctx, opts)
+			if err == nil {
+				return cli, nil
+			}
+
+			log.Infof("Failed to initialize scheduler clients: %s. Retrying...", err)
+			time.Sleep(time.Second)
+		}
+	}
 }
 
 func getPodName() string {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -387,17 +387,17 @@ func (a *DaprRuntime) Run(parentCtx context.Context) error {
 
 func continuouslyRetrySchedulerClient(ctx context.Context, opts clients.Options) (*clients.Clients, error) {
 	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
 			cli, err := clients.New(ctx, opts)
 			if err == nil {
 				return cli, nil
 			}
 
-			log.Infof("Failed to initialize scheduler clients: %s. Retrying...", err)
-			time.Sleep(time.Second)
+			log.Errorf("Failed to initialize scheduler clients: %s. Retrying...", err)
+select {
+			case <- time.After(time.Second):
+			case <-ctx.Done():
+			  return nil, ctx.Error()
+			  }
 		}
 	}
 }


### PR DESCRIPTION
Add retry logic on sidecar, such that if the first connection to scheduler fails, it keeps retrying continuously since if the scheduler is enabled, it should be able to connect.
