### PR TITLE
e2e tests scheduler-host-flag

### DIFF
--- a/tests/platforms/kubernetes/app_description.go
+++ b/tests/platforms/kubernetes/app_description.go
@@ -69,6 +69,7 @@ type AppDescription struct {
 	PluggableComponents       []apiv1.Container               `json:",omitempty"`
 	InjectPluggableComponents bool                            `json:",omitempty"`
 	PlacementAddresses        []string                        `json:",omitempty"`
+	SchedulerAddresses        []string                        `json:",omitempty"`
 	EnableAppHealthCheck      bool                            `json:",omitempty"`
 	AppHealthCheckPath        string                          `json:",omitempty"`
 	AppHealthProbeInterval    int                             `json:",omitempty"` // In seconds

--- a/tests/platforms/kubernetes/kubeobj.go
+++ b/tests/platforms/kubernetes/kubeobj.go
@@ -148,6 +148,9 @@ func buildDaprAnnotations(appDesc AppDescription) map[string]string {
 	if len(appDesc.PlacementAddresses) != 0 {
 		annotationObject["dapr.io/placement-host-address"] = strings.Join(appDesc.PlacementAddresses, ",")
 	}
+	if len(appDesc.SchedulerAddresses) != 0 {
+		annotationObject["dapr.io/scheduler-host-address"] = strings.Join(appDesc.SchedulerAddresses, ",")
+	}
 
 	if appDesc.InjectPluggableComponents {
 		annotationObject["dapr.io/inject-pluggable-components"] = "true"


### PR DESCRIPTION
This fixes the log in e2e output showing:
```
2024/05/24 23:52:21 previous pod: hellon1dapr-568d6d5b9d-w9zkm, logs: unknown flag: --scheduler-host-address

```

I must have not pushed it but had it locally. To get e2e tests working locally I had to make edits to these files and just forgot to add this change.

NOTE, this does not fix e2e test entirely. That will happen once actor reminders no longer default to using scheduler (in a follow up PR where I'll add a preview feature for it)