### PR TITLE
Scheduler fix int tests: quorum/notls on windows

### DIFF
--- a/tests/integration/suite/actors/reminders/scheduler/idtypes.go
+++ b/tests/integration/suite/actors/reminders/scheduler/idtypes.go
@@ -201,9 +201,9 @@ func (i *idtype) Run(t *testing.T, ctx context.Context) {
 		i.lock.Lock()
 		defer i.lock.Unlock()
 		return len(i.methodcalled) == i.actorIDsNum*i.actorTypesNum*i.daprdsNum
-	}, time.Second*10, time.Millisecond*10)
+	}, time.Second*20, time.Millisecond*10)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.ElementsMatch(t, i.expcalled, i.methodcalled)
-	}, time.Second*10, time.Millisecond*10)
+	}, time.Second*20, time.Millisecond*10)
 }

--- a/tests/integration/suite/scheduler/quorum/notls.go
+++ b/tests/integration/suite/scheduler/quorum/notls.go
@@ -133,7 +133,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		chosenSchedulerEtcdKeys := getEtcdKeys(t, chosenSchedulerPort)
 		checkKeysForJobName(t, n.daprd, "testJob", chosenSchedulerEtcdKeys)
-	}, time.Second*3, time.Millisecond*10, "failed to find job's key in etcd")
+	}, time.Second*15, time.Millisecond*10, "failed to find job's key in etcd")
 
 	// ensure data exists on ALL schedulers
 	for i := 0; i < 3; i++ {
@@ -145,7 +145,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			diffSchedulerEtcdKeys := getEtcdKeys(t, diffSchedulerPort)
 			checkKeysForJobName(t, n.daprd, "testJob", diffSchedulerEtcdKeys)
-		}, time.Second*3, time.Millisecond*10, "failed to find job's key in etcd")
+		}, time.Second*15, time.Millisecond*10, "failed to find job's key in etcd")
 	}
 }
 

--- a/tests/integration/suite/scheduler/quorum/notls.go
+++ b/tests/integration/suite/scheduler/quorum/notls.go
@@ -133,7 +133,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		chosenSchedulerEtcdKeys := getEtcdKeys(t, chosenSchedulerPort)
 		checkKeysForJobName(t, n.daprd, "testJob", chosenSchedulerEtcdKeys)
-	}, time.Second*15, time.Millisecond*10, "failed to find job's key in etcd")
+	}, time.Second*20, time.Millisecond*10, "failed to find job's key in etcd")
 
 	// ensure data exists on ALL schedulers
 	for i := 0; i < 3; i++ {
@@ -145,7 +145,7 @@ func (n *notls) Run(t *testing.T, ctx context.Context) {
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			diffSchedulerEtcdKeys := getEtcdKeys(t, diffSchedulerPort)
 			checkKeysForJobName(t, n.daprd, "testJob", diffSchedulerEtcdKeys)
-		}, time.Second*15, time.Millisecond*10, "failed to find job's key in etcd")
+		}, time.Second*20, time.Millisecond*10, "failed to find job's key in etcd")
 	}
 }
 


### PR DESCRIPTION
Im upping the time for the assert eventually in the test. It passes for my mac, and in CI for ubuntu and mac, so Im thinking windows just needs more time for the test. 