### PR TITLE
Scheduler fix workflow perf

### DIFF
--- a/tests/apps/perf/workflowsapp/app.py
+++ b/tests/apps/perf/workflowsapp/app.py
@@ -174,7 +174,7 @@ def run_workflow(run_id):
         sleep(0.5)
 
         workflow_state = workflowClient.wait_for_workflow_completion(
-                instance_id=instance_id, timeout_in_seconds=250)
+                instance_id=instance_id, timeout_in_seconds=1500)
         assert workflow_state.runtime_status == WorkflowStatus.COMPLETED
 
         try:

--- a/tests/perf/workflows/test.js
+++ b/tests/perf/workflows/test.js
@@ -86,7 +86,7 @@ function execute() {
         headers: {
             'Content-Type': 'application/json',
         },
-        timeout: '750s',
+        timeout: '1500s',
     }
     const res = http.post(
         `${__ENV.TARGET_URL}/${exec.scenario.iterationInTest}`,

--- a/tests/perf/workflows/workflow_test.go
+++ b/tests/perf/workflows/workflow_test.go
@@ -222,7 +222,7 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 func TestWorkflowWithConstantVUs(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_30_300", "t_30_300", "t_30_300"} // t_workflowCount_iterations
+	scenarios := []string{"t_30_300", "t_30_300", "t_30_300", "t_100000_100"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, false, false)
 }
@@ -230,7 +230,7 @@ func TestWorkflowWithConstantVUs(t *testing.T) {
 func TestWorkflowWithConstantIterations(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_30_300", "t_60_300", "t_90_300", "t_100000_100"} // t_workflowCount_iterations
+	scenarios := []string{"t_30_300", "t_60_300", "t_90_300"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
@@ -239,7 +239,7 @@ func TestWorkflowWithConstantIterations(t *testing.T) {
 func TestSeriesWorkflowWithMaxVUs(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_350_1400", "t_100000_100"} // t_workflowCount_iterations
+	scenarios := []string{"t_350_1400"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
@@ -256,7 +256,7 @@ func TestParallelWorkflowWithMaxVUs(t *testing.T) {
 // Runs tests for `state_wf` with different Payload
 func TestWorkflowWithDifferentPayloads(t *testing.T) {
 	workflowName := "state_wf"
-	scenarios := []string{"t_30_300", "t_100000_100"} // t_workflowCount_iterations
+	scenarios := []string{"t_30_300"} // t_workflowCount_iterations
 	inputs := []string{"10000", "50000", "100000"}
 	rateChecks := [][]string{{"rate==1"}, {"rate==1"}, {"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, true)

--- a/tests/perf/workflows/workflow_test.go
+++ b/tests/perf/workflows/workflow_test.go
@@ -222,7 +222,7 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 func TestWorkflowWithConstantVUs(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_30_300", "t_30_300", "t_30_300"}
+	scenarios := []string{"t_30_300", "t_30_300", "t_30_300"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, false, false)
 }
@@ -230,7 +230,7 @@ func TestWorkflowWithConstantVUs(t *testing.T) {
 func TestWorkflowWithConstantIterations(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_30_300", "t_60_300", "t_90_300"}
+	scenarios := []string{"t_30_300", "t_60_300", "t_90_300", "t_100000_100"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
@@ -239,7 +239,7 @@ func TestWorkflowWithConstantIterations(t *testing.T) {
 func TestSeriesWorkflowWithMaxVUs(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_350_1400"}
+	scenarios := []string{"t_350_1400", "t_100000_100"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
@@ -248,7 +248,7 @@ func TestSeriesWorkflowWithMaxVUs(t *testing.T) {
 func TestParallelWorkflowWithMaxVUs(t *testing.T) {
 	workflowName := "sum_parallel_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_110_440"}
+	scenarios := []string{"t_110_440", "t_100000_100"} // t_workflowCount_iterations
 	rateChecks := [][]string{{"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
@@ -256,17 +256,8 @@ func TestParallelWorkflowWithMaxVUs(t *testing.T) {
 // Runs tests for `state_wf` with different Payload
 func TestWorkflowWithDifferentPayloads(t *testing.T) {
 	workflowName := "state_wf"
-	scenarios := []string{"t_30_300"}
+	scenarios := []string{"t_30_300", "t_100000_100"} // t_workflowCount_iterations
 	inputs := []string{"10000", "50000", "100000"}
 	rateChecks := [][]string{{"rate==1"}, {"rate==1"}, {"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, true)
-}
-
-// Runs tests for `100k_wf` with 100,000 iterations
-func TestWorkflowWith100KIterations(t *testing.T) {
-	workflowName := "100k_wf"
-	inputs := []string{"100"}
-	scenarios := []string{"t_100000_100"} // 100k workflows, 100 iterations
-	rateChecks := [][]string{{"rate==1"}}
-	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }


### PR DESCRIPTION
I think we just needed to update the scenarios to run the 100k workflows `scenario` and not add a new func. 