### PR TITLE
reset workflow timeouts and vals/config

### DIFF
--- a/pkg/api/grpc/manager/manager.go
+++ b/pkg/api/grpc/manager/manager.go
@@ -40,8 +40,8 @@ import (
 const (
 	// needed to load balance requests for target services with multiple endpoints, ie. multiple instances.
 	grpcServiceConfig = `{"loadBalancingPolicy":"round_robin"}`
-	dialTimeout       = 30000 * time.Second
-	maxConnIdle       = 30000 * time.Minute
+	dialTimeout       = 30 * time.Second
+	maxConnIdle       = 3 * time.Minute
 )
 
 // ConnCreatorFn is a function that returns a gRPC connection
@@ -198,9 +198,9 @@ func (g *Manager) connectRemote(
 		g.sec.GRPCDialOptionMTLSUnknownTrustDomain(namespace, id),
 		grpc.WithKeepaliveParams(grpcKeepalive.ClientParameters{
 			// Ping the server every 10s if there's no activity
-			Time: 1000 * time.Second,
+			Time: 10 * time.Second,
 			// Wait 5s for the ping ACK before assuming the connection is dead
-			Timeout: 50000 * time.Second,
+			Timeout: 5 * time.Second,
 			// Send pings even without active streams
 			PermitWithoutStream: true,
 		}),

--- a/pkg/runtime/wfengine/backends/actors/activity_actor.go
+++ b/pkg/runtime/wfengine/backends/actors/activity_actor.go
@@ -73,7 +73,7 @@ func NewActivityActor(scheduler activityScheduler, backendConfig actorsBackendCo
 			actorID:          actorID,
 			actorRuntime:     actors,
 			scheduler:        scheduler,
-			defaultTimeout:   6 * time.Hour,
+			defaultTimeout:   1 * time.Hour,
 			reminderInterval: 1 * time.Minute,
 			config:           backendConfig,
 			cachingDisabled:  opts.cachingDisabled,
@@ -207,7 +207,7 @@ func (a *activityActor) executeActivity(ctx context.Context, name string, eventP
 	}()
 loop:
 	for {
-		t := time.NewTimer(100 * time.Minute)
+		t := time.NewTimer(10 * time.Minute)
 		select {
 		case <-ctx.Done():
 			if !t.Stop() {

--- a/pkg/scheduler/client/client.go
+++ b/pkg/scheduler/client/client.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dialTimeout = 30000 * time.Second
+	dialTimeout = 30 * time.Second
 )
 
 // New returns a new scheduler client and the underlying connection.

--- a/tests/apps/perf/workflowsapp/app.py
+++ b/tests/apps/perf/workflowsapp/app.py
@@ -174,7 +174,7 @@ def run_workflow(run_id):
         sleep(0.5)
 
         workflow_state = workflowClient.wait_for_workflow_completion(
-                instance_id=instance_id, timeout_in_seconds=10000000000)
+                instance_id=instance_id, timeout_in_seconds=750)
         assert workflow_state.runtime_status == WorkflowStatus.COMPLETED
 
         try:

--- a/tests/perf/workflows/workflow_test.go
+++ b/tests/perf/workflows/workflow_test.go
@@ -222,8 +222,8 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 func TestWorkflowWithConstantVUs(t *testing.T) {
 	workflowName := "sum_series_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_30_300", "t_30_300", "t_30_300", "t_10000_100"} // t_workflowCount_iterations
-	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1", "rate==1"}}
+	scenarios := []string{"t_30_300", "t_30_300", "t_30_300"} // t_workflowCount_iterations
+	rateChecks := [][]string{{"rate==1", "rate==1", "rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, false, false)
 }
 
@@ -248,8 +248,8 @@ func TestSeriesWorkflowWithMaxVUs(t *testing.T) {
 func TestParallelWorkflowWithMaxVUs(t *testing.T) {
 	workflowName := "sum_parallel_wf"
 	inputs := []string{"100"}
-	scenarios := []string{"t_110_440", "t_10000_100"} // t_workflowCount_iterations
-	rateChecks := [][]string{{"rate==1", "rate==1"}}
+	scenarios := []string{"t_110_440"} // t_workflowCount_iterations
+	rateChecks := [][]string{{"rate==1"}}
 	testWorkflow(t, workflowName, appNamePrefix, inputs, scenarios, rateChecks, true, false)
 }
 


### PR DESCRIPTION
reset workflow config/timeouts/vals to be whats in master and not what was from my scheduler testing.

This should be merged AFTER rnd work with scheduler for workflows is done